### PR TITLE
CGBA-48 Add metrics collection to connectors and controllers

### DIFF
--- a/app/metrics/IOMetrics.scala
+++ b/app/metrics/IOMetrics.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import cats.effect.IO
+import cats.effect.kernel.Deferred
+import cats.effect.kernel.Resource
+import cats.effect.kernel.Resource.ExitCase
+import com.codahale.metrics.MetricRegistry
+import com.kenshoo.play.metrics.Metrics
+import play.api.mvc.Result
+import uk.gov.hmrc.http.UpstreamErrorResponse
+
+trait IOMetrics {
+  def metrics: Metrics
+
+  private lazy val registry: MetricRegistry = metrics.defaultRegistry
+
+  class MetricsTimer private[metrics] (metricKey: String, timerCompleted: Deferred[IO, Boolean]) {
+    val timerContext   = registry.timer(s"$metricKey-timer").time()
+    val successCounter = registry.counter(s"$metricKey-success-counter")
+    val failureCounter = registry.counter(s"$metricKey-failed-counter")
+
+    def completeWithSuccess(): IO[Unit] =
+      timerCompleted
+        .complete(false)
+        .ifM(
+          // First call to complete this deferred value
+          ifTrue = IO {
+            timerContext.stop()
+            successCounter.inc()
+          },
+          // The deferred value was already completed
+          ifFalse = IO.unit
+        )
+
+    def completeWithFailure(): IO[Unit] =
+      timerCompleted
+        .complete(false)
+        .ifM(
+          // First call to complete this deferred value
+          ifTrue = IO {
+            timerContext.stop()
+            failureCounter.inc()
+          },
+          // The deferred value was already completed
+          ifFalse = IO.unit
+        )
+  }
+
+  def withMetricsTimer[A](metricKey: String)(block: MetricsTimer => IO[A]): IO[A] =
+    timerResource(metricKey).use(block)
+
+  def withMetricsTimerResponse[A](
+    metricKey: String
+  )(block: IO[Either[UpstreamErrorResponse, A]]): IO[Either[UpstreamErrorResponse, A]] =
+    timerResource(metricKey).use { timer =>
+      block.flatMap { result =>
+        val completeTimer =
+          if (result.isLeft)
+            timer.completeWithFailure()
+          else
+            timer.completeWithSuccess()
+
+        completeTimer.as(result)
+      }
+    }
+
+  def withMetricsTimerResult[A](metricKey: String)(block: IO[Result]): IO[Result] =
+    timerResource(metricKey).use { timer =>
+      block.flatMap { result =>
+        val completeTimer =
+          if (isFailureStatus(result.header.status))
+            timer.completeWithFailure()
+          else
+            timer.completeWithSuccess()
+
+        completeTimer.as(result)
+      }
+    }
+
+  private def timerResource(metricKey: String): Resource[IO, MetricsTimer] = {
+    val acquireTimer = for {
+      deferred <- IO.deferred[Boolean]
+      timer    <- IO(new MetricsTimer(metricKey, deferred))
+    } yield timer
+
+    Resource.makeCase(acquireTimer) {
+      case (timer, ExitCase.Succeeded) =>
+        timer.completeWithSuccess()
+      case (timer, ExitCase.Errored(_)) =>
+        timer.completeWithFailure()
+      case (timer, ExitCase.Canceled) =>
+        timer.completeWithFailure()
+    }
+  }
+
+  private def isFailureStatus(status: Int) =
+    status / 100 >= 4
+}

--- a/app/metrics/MetricsKeys.scala
+++ b/app/metrics/MetricsKeys.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+object MetricsKeys {
+  val ResponseTime = "response-time"
+
+  object Connectors {
+    val SendMessage = "send-message"
+  }
+
+  object Controllers {
+    val SubmitBalanceRequest = "submit-balance-request"
+    val GetBalanceRequest    = "get-balance-request"
+    val UpdateBalanceRequest = "update-balance-request"
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -31,6 +31,7 @@ object AppDependencies {
     "uk.gov.hmrc"           %% "bootstrap-test-play-28"   % bootstrapVersion,
     "uk.gov.hmrc.mongo"     %% "hmrc-mongo-test-play-28"  % hmrcMongoVersion,
     "com.typesafe.akka"     %% "akka-testkit"             % PlayVersion.akkaVersion,
+    "org.mockito"           %% "mockito-scala"            % "1.16.42",
     "com.github.tomakehurst" % "wiremock-jre8-standalone" % "2.31.0",
     "com.vladsch.flexmark"   % "flexmark-all"             % "0.62.2"
   ).map(_ % s"$Test, $IntegrationTest")

--- a/test/controllers/BalanceRequestControllerSpec.scala
+++ b/test/controllers/BalanceRequestControllerSpec.scala
@@ -22,6 +22,7 @@ import cats.effect.unsafe.IORuntime
 import config.AppConfig
 import config.Constants
 import controllers.actions.FakeAuthActionProvider
+import metrics.FakeMetrics
 import models.BalanceRequestFunctionalError
 import models.BalanceRequestResponse
 import models.BalanceRequestSuccess
@@ -75,7 +76,8 @@ class BalanceRequestControllerSpec extends AnyFlatSpec with Matchers {
       FakeAuthActionProvider,
       service,
       Helpers.stubControllerComponents(),
-      IORuntime.global
+      IORuntime.global,
+      new FakeMetrics
     )
   }
 

--- a/test/controllers/BalanceRequestResponseControllerSpec.scala
+++ b/test/controllers/BalanceRequestResponseControllerSpec.scala
@@ -20,6 +20,7 @@ import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import config.Constants
+import metrics.FakeMetrics
 import models.MessageType
 import models.SchemaValidationError
 import models.errors.BalanceRequestError
@@ -44,7 +45,8 @@ class BalanceRequestResponseControllerSpec extends AnyFlatSpec with Matchers {
     new BalanceRequestResponseController(
       service,
       Helpers.stubControllerComponents(),
-      IORuntime.global
+      IORuntime.global,
+      new FakeMetrics
     )
   }
 

--- a/test/metrics/IOMetricsSpec.scala
+++ b/test/metrics/IOMetricsSpec.scala
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.effect.unsafe.implicits.global
+import com.codahale.metrics.Counter
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.Timer
+import com.kenshoo.play.metrics.Metrics
+import controllers.actions.IOActions
+import org.mockito.ArgumentMatchersSugar
+import org.mockito.IdiomaticMockito
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.test.FakeRequest
+import play.api.test.Helpers
+import play.api.test.Helpers._
+import runtime.IOFutures
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import java.util.concurrent.CancellationException
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class IOMetricsSpec
+  extends AnyFlatSpec
+  with Matchers
+  with BeforeAndAfterEach
+  with IdiomaticMockito
+  with ArgumentMatchersSugar {
+
+  class IOMetricsConnector(val metrics: Metrics) extends IOFutures with IOMetrics {
+    def okHttpCall =
+      withMetricsTimerResponse("connector-ok") {
+        IO.runFuture { _ => Future.successful(Right(1)) }
+      }
+
+    def clientErrorHttpCall =
+      withMetricsTimerResponse("connector-client-error") {
+        IO.runFuture { _ => Future.successful(Left(UpstreamErrorResponse("Arghhh!!!", 400))) }
+      }
+
+    def serverErrorHttpCall =
+      withMetricsTimerResponse("connector-server-error") {
+        IO.runFuture { _ => Future.successful(Left(UpstreamErrorResponse("Kaboom!!!", 502))) }
+      }
+
+    def unhandledExceptionHttpCall =
+      withMetricsTimerResponse("connector-unhandled-exception") {
+        IO.runFuture { _ => Future.failed(new RuntimeException) }
+      }
+
+    def cancelledHttpCall =
+      withMetricsTimerResponse("connector-unhandled-exception") {
+        IO.canceled.as(Right(1))
+      }
+
+    def autoCompleteWithSuccessCall =
+      withMetricsTimer("connector-auto-success")(_ => IO.unit)
+
+    def autoCompleteWithFailureErrorCall =
+      withMetricsTimer("connector-auto-success")(_ => IO.raiseError[Int](new RuntimeException))
+
+    def autoCompleteWithFailureCancelledCall =
+      withMetricsTimer("connector-auto-success")(_ => IO.canceled)
+
+    def manualCompleteSuccessCall =
+      withMetricsTimer("connector-manual-success")(_.completeWithSuccess())
+
+    def manualCompleteFailureCall =
+      withMetricsTimer("connector-manual-failure")(_.completeWithFailure())
+  }
+
+  class IOMetricsController(val metrics: Metrics, val runtime: IORuntime)
+    extends BackendController(Helpers.stubControllerComponents())
+    with IOActions
+    with IOMetrics {
+
+    def okEndpoint = Action.io {
+      withMetricsTimerResult("controller-ok") {
+        IO.sleep(50.millis).as(Ok)
+      }
+    }
+
+    def clientErrorEndpoint = Action.io {
+      withMetricsTimerResult("controller-client-error") {
+        IO.sleep(50.millis).as(BadRequest)
+      }
+    }
+
+    def serverErrorEndpoint = Action.io {
+      withMetricsTimerResult("controller-server-error") {
+        IO.sleep(50.millis).as(BadGateway)
+      }
+    }
+
+    def unhandledExceptionEndpoint = Action.io {
+      withMetricsTimerResult("controller-unhandled-exception") {
+        IO.raiseError(new RuntimeException).as(Ok)
+      }
+    }
+
+    def cancelledEndpoint = Action.io {
+      withMetricsTimerResult("controller-unhandled-exception") {
+        IO.canceled.as(Ok)
+      }
+    }
+  }
+
+  val metrics        = mock[Metrics]
+  val registry       = mock[MetricRegistry]
+  val timer          = mock[Timer]
+  val timerContext   = mock[Timer.Context]
+  val successCounter = mock[Counter]
+  val failureCounter = mock[Counter]
+
+  override protected def beforeEach(): Unit = {
+    reset(metrics, registry, timer, timerContext, successCounter, failureCounter)
+    metrics.defaultRegistry returns registry
+    registry.timer(*[String]) returns timer
+    registry.counter(endsWith("-success-counter")) returns successCounter
+    registry.counter(endsWith("-failed-counter")) returns failureCounter
+    timer.time() returns timerContext
+  }
+
+  "IOMetrics.withMetricsTimer" should "complete with success when the call completes successfully" in {
+    val connector = new IOMetricsConnector(metrics)
+    connector.autoCompleteWithSuccessCall.unsafeRunSync()
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    successCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the IO action raises an error" in {
+    val connector = new IOMetricsConnector(metrics)
+    assertThrows[RuntimeException] {
+      connector.autoCompleteWithFailureErrorCall.unsafeRunSync()
+    }
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when there is an unhandled runtime exception in the HTTP Future call" in {
+    val connector = new IOMetricsConnector(metrics)
+    assertThrows[RuntimeException] {
+      connector.unhandledExceptionHttpCall.unsafeRunSync()
+    }
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the IO is cancelled" in {
+    val connector = new IOMetricsConnector(metrics)
+    assertThrows[CancellationException] {
+      connector.cancelledHttpCall.unsafeRunSync()
+    }
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  it should "complete with success when the user calls completeWithSuccess explicitly" in {
+    val connector = new IOMetricsConnector(metrics)
+    connector.manualCompleteSuccessCall.unsafeRunSync()
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    successCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the user calls completeWithFailure explicitly" in {
+    val connector = new IOMetricsConnector(metrics)
+    connector.manualCompleteFailureCall.unsafeRunSync()
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  "IOMetrics.withMetricsTimerResponse" should "complete with success when the HTTP response is a success" in {
+    val connector = new IOMetricsConnector(metrics)
+    connector.okHttpCall.unsafeRunSync()
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    successCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the HTTP response is a client error" in {
+    val connector = new IOMetricsConnector(metrics)
+    connector.clientErrorHttpCall.unsafeRunSync()
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the HTTP response is a server error" in {
+    val connector = new IOMetricsConnector(metrics)
+    connector.serverErrorHttpCall.unsafeRunSync()
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the IO action is cancelled" in {
+    val connector = new IOMetricsConnector(metrics)
+    assertThrows[CancellationException] {
+      connector.cancelledHttpCall.unsafeRunSync()
+    }
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when there is an unhandled runtime exception" in {
+    val connector = new IOMetricsConnector(metrics)
+    assertThrows[RuntimeException] {
+      connector.unhandledExceptionHttpCall.unsafeRunSync()
+    }
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  "IOMetrics.withMetricsTimerResult" should "complete with success when the result has a successful status code" in {
+    val controller = new IOMetricsController(metrics, global)
+    val result     = controller.okEndpoint(FakeRequest())
+    status(result) shouldBe OK
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    successCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the result has a client error status code" in {
+    val controller = new IOMetricsController(metrics, global)
+    val result     = controller.clientErrorEndpoint(FakeRequest())
+    status(result) shouldBe BAD_REQUEST
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the result has a server error status code" in {
+    val controller = new IOMetricsController(metrics, global)
+    val result     = controller.serverErrorEndpoint(FakeRequest())
+    status(result) shouldBe BAD_GATEWAY
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the server has an unhandled runtime exception" in {
+    val controller = new IOMetricsController(metrics, global)
+    assertThrows[RuntimeException] {
+      await(controller.unhandledExceptionEndpoint(FakeRequest()))
+    }
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+
+  it should "complete with failure when the request handling IO action is cancelled" in {
+    val controller = new IOMetricsController(metrics, global)
+    assertThrows[CancellationException] {
+      await(controller.cancelledEndpoint(FakeRequest()))
+    }
+    timer.time() wasCalled once
+    timerContext.stop() wasCalled once
+    failureCounter.inc() wasCalled once
+  }
+}

--- a/test/services/BalanceRequestCacheServiceSpec.scala
+++ b/test/services/BalanceRequestCacheServiceSpec.scala
@@ -84,7 +84,8 @@ class BalanceRequestCacheServiceSpec extends AsyncFlatSpec with Matchers {
       parser,
       FakeEisRouterConnector(sendMessageResponse),
       appConfig,
-      Clock.systemUTC()
+      Clock.systemUTC(),
+      new FakeMetrics
     )
 
     new BalanceRequestCacheServiceImpl(

--- a/test/services/BalanceRequestServiceSpec.scala
+++ b/test/services/BalanceRequestServiceSpec.scala
@@ -21,6 +21,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import config.AppConfig
 import connectors.FakeEisRouterConnector
+import metrics.FakeMetrics
 import models.BalanceRequestResponse
 import models.BalanceRequestSuccess
 import models.MessageType
@@ -82,7 +83,8 @@ class BalanceRequestServiceSpec extends AsyncFlatSpec with Matchers {
       parser,
       FakeEisRouterConnector(sendMessageResponse),
       appConfig,
-      Clock.systemUTC()
+      Clock.systemUTC(),
+      new FakeMetrics
     )
   }
 


### PR DESCRIPTION
This adds basic metrics collection to the service.

At the moment the following are instrumented:
* HTTP endpoints
* Connector calls
* The time between a balance request message being sent and a response being received from NCTS