### PR TITLE
Simplify caching solution so that it's only used for awaiting async responses

### DIFF
--- a/app/controllers/BalanceRequestController.scala
+++ b/app/controllers/BalanceRequestController.scala
@@ -82,7 +82,7 @@ class BalanceRequestController @Inject() (
       withMetricsTimerResult(SubmitBalanceRequest) {
         requireChannelHeader {
           service
-            .getBalance(request.enrolmentId, request.body)
+            .submitBalanceRequest(request.enrolmentId, request.body)
             .flatTap(logServiceError("submitting balance request", _))
             .map {
               case Right(success @ BalanceRequestSuccess(_, _)) =>

--- a/app/repositories/BalanceRequestRepository.scala
+++ b/app/repositories/BalanceRequestRepository.scala
@@ -26,9 +26,7 @@ import models.formats.MongoFormats
 import models.request.BalanceRequest
 import models.values.BalanceId
 import models.values.EnrolmentId
-import models.values.GuaranteeReference
 import models.values.MessageIdentifier
-import models.values.TaxIdentifier
 import org.bson.UuidRepresentation
 import org.bson.codecs.UuidCodec
 import org.mongodb.scala.model.Filters
@@ -37,7 +35,6 @@ import org.mongodb.scala.model.IndexModel
 import org.mongodb.scala.model.IndexOptions
 import org.mongodb.scala.model.Indexes
 import org.mongodb.scala.model.ReturnDocument
-import org.mongodb.scala.model.Sorts
 import org.mongodb.scala.model.Updates
 import retry.RetryPolicies
 import retry.syntax.all._
@@ -57,12 +54,6 @@ import scala.concurrent.ExecutionContext
 @ImplementedBy(classOf[BalanceRequestRepositoryImpl])
 trait BalanceRequestRepository {
   def getBalanceRequest(balanceId: BalanceId): IO[Option[PendingBalanceRequest]]
-
-  def getBalanceRequest(
-    enrolmentId: EnrolmentId,
-    taxIdentifier: TaxIdentifier,
-    guaranteeReference: GuaranteeReference
-  ): IO[Option[PendingBalanceRequest]]
 
   def insertBalanceRequest(
     enrolmentId: EnrolmentId,
@@ -126,23 +117,6 @@ class BalanceRequestRepositoryImpl @Inject() (
   def getBalanceRequest(balanceId: BalanceId): IO[Option[PendingBalanceRequest]] =
     IO.observeFirstOption {
       collection.find(Filters.eq("_id", balanceId.value))
-    }
-
-  def getBalanceRequest(
-    enrolmentId: EnrolmentId,
-    taxIdentifier: TaxIdentifier,
-    guaranteeReference: GuaranteeReference
-  ): IO[Option[PendingBalanceRequest]] =
-    IO.observeFirstOption {
-      collection
-        .find(
-          Filters.and(
-            Filters.eq("enrolmentId", enrolmentId.value),
-            Filters.eq("taxIdentifier", taxIdentifier.value),
-            Filters.eq("guaranteeReference", guaranteeReference.value)
-          )
-        )
-        .sort(Sorts.descending("requestedAt"))
     }
 
   def insertBalanceRequest(

--- a/app/services/BalanceRequestCacheService.scala
+++ b/app/services/BalanceRequestCacheService.scala
@@ -35,9 +35,7 @@ import models.errors._
 import models.request.BalanceRequest
 import models.values.BalanceId
 import models.values.EnrolmentId
-import models.values.GuaranteeReference
 import models.values.MessageIdentifier
-import models.values.TaxIdentifier
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.util.concurrent.TimeoutException
@@ -46,7 +44,7 @@ import javax.inject.Singleton
 
 @ImplementedBy(classOf[BalanceRequestCacheServiceImpl])
 trait BalanceRequestCacheService {
-  def getBalance(
+  def submitBalanceRequest(
     enrolmentId: EnrolmentId,
     balanceRequest: BalanceRequest
   )(implicit hc: HeaderCarrier): IO[Either[BalanceRequestError, BalanceRequestResponse]]
@@ -56,9 +54,7 @@ trait BalanceRequestCacheService {
   )(implicit hc: HeaderCarrier): IO[Option[PendingBalanceRequest]]
 
   def putBalance(
-    enrolmentId: EnrolmentId,
-    taxIdentifier: TaxIdentifier,
-    guaranteeReference: GuaranteeReference,
+    balanceId: BalanceId,
     response: BalanceRequestResponse
   ): IO[Unit]
 
@@ -78,7 +74,7 @@ class BalanceRequestCacheServiceImpl @Inject() (
   with Logging
   with ErrorLogging {
 
-  type CacheKey         = (EnrolmentId, TaxIdentifier, GuaranteeReference)
+  type CacheKey         = BalanceId
   type DeferredResponse = Deferred[IO, BalanceRequestResponse]
 
   private val cache: LoadingCache[CacheKey, DeferredResponse] = Scaffeine()
@@ -92,18 +88,6 @@ class BalanceRequestCacheServiceImpl @Inject() (
     hc: HeaderCarrier
   ): EitherT[IO, BalanceRequestError, BalanceId] =
     EitherT(service.submitBalanceRequest(enrolmentId, balanceRequest))
-
-  private def getRequest(
-    enrolmentId: EnrolmentId,
-    balanceRequest: BalanceRequest
-  ): EitherT[IO, BalanceRequestError, Option[PendingBalanceRequest]] =
-    EitherT.right[BalanceRequestError](
-      service.getBalanceRequest(
-        enrolmentId,
-        balanceRequest.taxIdentifier,
-        balanceRequest.guaranteeReference
-      )
-    )
 
   private def awaitResponse(
     balanceId: BalanceId,
@@ -119,58 +103,19 @@ class BalanceRequestCacheServiceImpl @Inject() (
     }
   }
 
-  private def fetchNewBalance(
-    enrolmentId: EnrolmentId,
-    balanceRequest: BalanceRequest,
-    deferredResponse: DeferredResponse
-  )(implicit hc: HeaderCarrier): IO[Either[BalanceRequestError, BalanceRequestResponse]] = {
-
-    val balanceResponse = for {
-      balanceId <- submitRequest(enrolmentId, balanceRequest)
-      response  <- awaitResponse(balanceId, deferredResponse)
-    } yield response
-
-    balanceResponse.value
-  }
-
-  private def awaitExistingBalanceRequest(
-    enrolmentId: EnrolmentId,
-    balanceRequest: BalanceRequest,
-    deferred: DeferredResponse
-  ): IO[Either[BalanceRequestError, BalanceRequestResponse]] = {
-    val getBalanceResponse = for {
-      maybeRequest <- getRequest(enrolmentId, balanceRequest)
-
-      balanceId <- EitherT.fromOptionM(
-        IO.pure(maybeRequest.map(_.balanceId)),
-        logger
-          .error("Unable to fetch database record for a cached balance request")
-          .map(_ => BalanceRequestError.internalServiceError())
-      )
-
-      response <- awaitResponse(balanceId, deferred)
-
-    } yield response
-
-    getBalanceResponse.value
-  }
-
-  def getBalance(
+  def submitBalanceRequest(
     enrolmentId: EnrolmentId,
     balanceRequest: BalanceRequest
   )(implicit hc: HeaderCarrier): IO[Either[BalanceRequestError, BalanceRequestResponse]] = {
 
-    val cacheKey = (enrolmentId, balanceRequest.taxIdentifier, balanceRequest.guaranteeReference)
+    val balanceResponse = for {
+      balanceId <- submitRequest(enrolmentId, balanceRequest)
+      deferred = cache.get(balanceId)
+      response <- awaitResponse(balanceId, deferred)
+      _ = cache.invalidate(balanceId)
+    } yield response
 
-    IO(cache.getIfPresent(cacheKey)).flatMap {
-      case Some(deferred) =>
-        awaitExistingBalanceRequest(enrolmentId, balanceRequest, deferred)
-      case None =>
-        for {
-          deferred <- IO(cache.get(cacheKey))
-          response <- fetchNewBalance(enrolmentId, balanceRequest, deferred)
-        } yield response
-    }
+    balanceResponse.value
   }
 
   def getBalance(
@@ -179,15 +124,11 @@ class BalanceRequestCacheServiceImpl @Inject() (
     service.getBalanceRequest(balanceId)
 
   def putBalance(
-    enrolmentId: EnrolmentId,
-    taxIdentifier: TaxIdentifier,
-    guaranteeReference: GuaranteeReference,
+    balanceId: BalanceId,
     response: BalanceRequestResponse
   ): IO[Unit] = {
-    val cacheKey = (enrolmentId, taxIdentifier, guaranteeReference)
-
     for {
-      deferred <- IO(cache.get(cacheKey))
+      deferred <- IO(cache.get(balanceId))
       _        <- deferred.complete(response)
     } yield ()
   }
@@ -210,7 +151,7 @@ class BalanceRequestCacheServiceImpl @Inject() (
       )
 
       _ <- EitherT.right[BalanceRequestError] {
-        putBalance(updated.enrolmentId, updated.taxIdentifier, updated.guaranteeReference, response)
+        putBalance(updated.balanceId, response)
       }
 
     } yield ()

--- a/app/services/BalanceRequestService.scala
+++ b/app/services/BalanceRequestService.scala
@@ -31,9 +31,7 @@ import models.errors._
 import models.request.BalanceRequest
 import models.values.BalanceId
 import models.values.EnrolmentId
-import models.values.GuaranteeReference
 import models.values.MessageIdentifier
-import models.values.TaxIdentifier
 import models.values.UniqueReference
 import repositories.BalanceRequestRepository
 import uk.gov.hmrc.http.HeaderCarrier
@@ -103,13 +101,6 @@ class BalanceRequestService @Inject() (
     balanceId: BalanceId
   ): IO[Option[PendingBalanceRequest]] =
     repository.getBalanceRequest(balanceId)
-
-  def getBalanceRequest(
-    enrolmentId: EnrolmentId,
-    taxIdentifier: TaxIdentifier,
-    guaranteeReference: GuaranteeReference
-  ): IO[Option[PendingBalanceRequest]] =
-    repository.getBalanceRequest(enrolmentId, taxIdentifier, guaranteeReference)
 
   private def validateResponseMessage(
     messageType: MessageType,

--- a/test/repositories/BalanceRequestRepositorySpec.scala
+++ b/test/repositories/BalanceRequestRepositorySpec.scala
@@ -96,62 +96,6 @@ class BalanceRequestRepositorySpec
       await(assertion.unsafeToFuture())
   }
 
-  it should "round trip pending balance requests by identifiers" in forAll {
-    (enrolmentId: EnrolmentId, request: BalanceRequest, requestedAt: Instant) =>
-      val assertion = for {
-        id <- repository.insertBalanceRequest(enrolmentId, request, requestedAt)
-
-        expected = PendingBalanceRequest(
-          balanceId = id,
-          enrolmentId = enrolmentId,
-          taxIdentifier = request.taxIdentifier,
-          guaranteeReference = request.guaranteeReference,
-          requestedAt = requestedAt,
-          completedAt = None,
-          response = None
-        )
-
-        actual <- repository.getBalanceRequest(
-          enrolmentId,
-          request.taxIdentifier,
-          request.guaranteeReference
-        )
-
-      } yield actual should contain(expected)
-
-      await(assertion.unsafeToFuture())
-  }
-
-  it should "return latest request when searching by identifiers" in forAll {
-    (enrolmentId: EnrolmentId, request: BalanceRequest, requestedAt: Instant) =>
-      val assertion = for {
-        _ <- repository.insertBalanceRequest(enrolmentId, request, requestedAt)
-
-        _ <- repository.insertBalanceRequest(enrolmentId, request, requestedAt.plusSeconds(60))
-
-        id3 <- repository.insertBalanceRequest(enrolmentId, request, requestedAt.plusSeconds(120))
-
-        expected = PendingBalanceRequest(
-          balanceId = id3,
-          enrolmentId = enrolmentId,
-          taxIdentifier = request.taxIdentifier,
-          guaranteeReference = request.guaranteeReference,
-          requestedAt = requestedAt.plusSeconds(120),
-          completedAt = None,
-          response = None
-        )
-
-        actual <- repository.getBalanceRequest(
-          enrolmentId,
-          request.taxIdentifier,
-          request.guaranteeReference
-        )
-
-      } yield actual should contain(expected)
-
-      await(assertion.unsafeToFuture())
-  }
-
   it should "update balance requests with responses" in forAll {
     (
       enrolmentId: EnrolmentId,

--- a/test/repositories/FakeBalanceRequestRepository.scala
+++ b/test/repositories/FakeBalanceRequestRepository.scala
@@ -22,9 +22,7 @@ import models.PendingBalanceRequest
 import models.request.BalanceRequest
 import models.values.BalanceId
 import models.values.EnrolmentId
-import models.values.GuaranteeReference
 import models.values.MessageIdentifier
-import models.values.TaxIdentifier
 
 import java.time.Instant
 
@@ -35,13 +33,6 @@ case class FakeBalanceRequestRepository(
 ) extends BalanceRequestRepository {
 
   override def getBalanceRequest(balanceId: BalanceId): IO[Option[PendingBalanceRequest]] =
-    getBalanceRequestResponse
-
-  override def getBalanceRequest(
-    enrolmentId: EnrolmentId,
-    taxIdentifier: TaxIdentifier,
-    guaranteeReference: GuaranteeReference
-  ): IO[Option[PendingBalanceRequest]] =
     getBalanceRequestResponse
 
   override def insertBalanceRequest(

--- a/test/services/BalanceRequestServiceSpec.scala
+++ b/test/services/BalanceRequestServiceSpec.scala
@@ -240,31 +240,7 @@ class BalanceRequestServiceSpec extends AsyncFlatSpec with Matchers {
       .unsafeToFuture()
   }
 
-  "BalanceRequestService.getBalanceRequest" should "return balance request for provided identifiers when found" in {
-    service(
-      getBalanceRequestResponse = IO.pure(Some(pendingBalanceRequest))
-    ).getBalanceRequest(
-      enrolmentId,
-      balanceRequest.taxIdentifier,
-      balanceRequest.guaranteeReference
-    ).map {
-      _ shouldBe Some(pendingBalanceRequest)
-    }.unsafeToFuture()
-  }
-
-  it should "return None for provided identifiers when the balance request is not found" in {
-    service(
-      getBalanceRequestResponse = IO.pure(None)
-    ).getBalanceRequest(
-      enrolmentId,
-      balanceRequest.taxIdentifier,
-      balanceRequest.guaranteeReference
-    ).map {
-      _ shouldBe None
-    }.unsafeToFuture()
-  }
-
-  "BalanceRequestService.getBalanceRequest by ID" should "delegate to repository" in {
+  "BalanceRequestService.getBalanceRequest" should "delegate to repository" in {
     val uuid        = UUID.fromString("22b9899e-24ee-48e6-a189-97d1f45391c4")
     val balanceId   = BalanceId(uuid)
     val enrolmentId = EnrolmentId("12345678ABC")

--- a/test/services/FakeBalanceRequestCacheService.scala
+++ b/test/services/FakeBalanceRequestCacheService.scala
@@ -24,9 +24,7 @@ import models.errors.BalanceRequestError
 import models.request.BalanceRequest
 import models.values.BalanceId
 import models.values.EnrolmentId
-import models.values.GuaranteeReference
 import models.values.MessageIdentifier
-import models.values.TaxIdentifier
 import uk.gov.hmrc.http.HeaderCarrier
 
 case class FakeBalanceRequestCacheService(
@@ -41,15 +39,13 @@ case class FakeBalanceRequestCacheService(
   ): IO[Option[PendingBalanceRequest]] =
     getBalanceByIdResponse
 
-  override def getBalance(enrolmentId: EnrolmentId, balanceRequest: BalanceRequest)(implicit
-    hc: HeaderCarrier
+  override def submitBalanceRequest(enrolmentId: EnrolmentId, balanceRequest: BalanceRequest)(
+    implicit hc: HeaderCarrier
   ): IO[Either[BalanceRequestError, BalanceRequestResponse]] =
     getBalanceResponse
 
   override def putBalance(
-    enrolmentId: EnrolmentId,
-    taxIdentifier: TaxIdentifier,
-    guaranteeReference: GuaranteeReference,
+    balanceId: BalanceId,
     response: BalanceRequestResponse
   ): IO[Unit] =
     putBalanceResponse


### PR DESCRIPTION
While working on #16 I observed that removing the caching behaviour except as a synchronisation point for the async response simplifies the code a lot. It also removes a lot of gotchas for users like:

* submit request with wrong access code
* get a rejection from NCTS
* submit a new request with correct access code
* get the same rejection because we're within the caching period
