### PR TITLE
CGBA-50: Add metrics for the balance request responses

### DIFF
--- a/app/controllers/testOnly/TestOnlyMongoController.scala
+++ b/app/controllers/testOnly/TestOnlyMongoController.scala
@@ -19,8 +19,11 @@ package controllers.testOnly
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import controllers.actions.IOActions
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import repositories.{BalanceRequestRepository, IOObservables}
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
+import repositories.BalanceRequestRepository
+import repositories.IOObservables
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 

--- a/app/metrics/IOMetrics.scala
+++ b/app/metrics/IOMetrics.scala
@@ -20,6 +20,7 @@ import cats.effect.IO
 import cats.effect.kernel.Deferred
 import cats.effect.kernel.Resource
 import cats.effect.kernel.Resource.ExitCase
+import com.codahale.metrics.Histogram
 import com.codahale.metrics.MetricRegistry
 import com.kenshoo.play.metrics.Metrics
 import play.api.mvc.Result
@@ -92,6 +93,9 @@ trait IOMetrics {
         completeTimer.as(result)
       }
     }
+
+  def histogram(metricKey: String): Histogram =
+    registry.histogram(metricKey)
 
   private def timerResource(metricKey: String): Resource[IO, MetricsTimer] = {
     val acquireTimer = for {

--- a/app/metrics/MetricsKeys.scala
+++ b/app/metrics/MetricsKeys.scala
@@ -27,5 +27,6 @@ object MetricsKeys {
     val SubmitBalanceRequest = "submit-balance-request"
     val GetBalanceRequest    = "get-balance-request"
     val UpdateBalanceRequest = "update-balance-request"
+    val BalanceResponseSize  = "balance-request-response-size"
   }
 }

--- a/app/services/ErrorTranslationService.scala
+++ b/app/services/ErrorTranslationService.scala
@@ -16,6 +16,7 @@
 
 package services
 
+import com.google.inject.ImplementedBy
 import models.errors.FunctionalError
 import models.errors.XmlError
 import models.values.ErrorPointer
@@ -23,7 +24,6 @@ import models.values.ErrorType
 
 import javax.inject.Inject
 import javax.inject.Singleton
-import com.google.inject.ImplementedBy
 
 @ImplementedBy(classOf[ErrorTranslationServiceImpl])
 trait ErrorTranslationService {

--- a/test/controllers/BalanceRequestResponseControllerSpec.scala
+++ b/test/controllers/BalanceRequestResponseControllerSpec.scala
@@ -36,6 +36,7 @@ import services.FakeBalanceRequestCacheService
 import uk.gov.hmrc.http.UpstreamErrorResponse
 
 import java.util.UUID
+import play.api.http.HeaderNames
 
 class BalanceRequestResponseControllerSpec extends AnyFlatSpec with Matchers {
 
@@ -52,11 +53,42 @@ class BalanceRequestResponseControllerSpec extends AnyFlatSpec with Matchers {
 
   val uuid      = UUID.fromString("22b9899e-24ee-48e6-a189-97d1f45391c4")
   val balanceId = BalanceId(uuid)
+  val headers = Seq(
+    Constants.MessageTypeHeader -> MessageType.ResponseQueryOnGuarantees.code,
+    HeaderNames.CONTENT_LENGTH  -> "0"
+  )
 
   "BalanceRequestResponseController" should "return 200 when successful" in {
     val request = FakeRequest()
       .withBody("")
+      .withHeaders(headers: _*)
+
+    val result = controller(
+      updateBalanceResponse = IO.unit.map(Right.apply)
+    ).updateBalanceRequest(balanceId.messageIdentifier)(request)
+
+    status(result) shouldBe OK
+  }
+
+  "BalanceRequestResponseController" should "return 200 when successful even if content length is missing" in {
+    val request = FakeRequest()
+      .withBody("")
       .withHeaders(Constants.MessageTypeHeader -> MessageType.ResponseQueryOnGuarantees.code)
+
+    val result = controller(
+      updateBalanceResponse = IO.unit.map(Right.apply)
+    ).updateBalanceRequest(balanceId.messageIdentifier)(request)
+
+    status(result) shouldBe OK
+  }
+
+  "BalanceRequestResponseController" should "return 200 when successful even if content length cannot be parsed" in {
+    val request = FakeRequest()
+      .withBody("")
+      .withHeaders(
+        Constants.MessageTypeHeader -> MessageType.ResponseQueryOnGuarantees.code,
+        HeaderNames.CONTENT_LENGTH  -> "abc"
+      )
 
     val result = controller(
       updateBalanceResponse = IO.unit.map(Right.apply)
@@ -82,7 +114,7 @@ class BalanceRequestResponseControllerSpec extends AnyFlatSpec with Matchers {
   it should "return 400 when there is an error in the request data" in {
     val request = FakeRequest()
       .withBody("")
-      .withHeaders(Constants.MessageTypeHeader -> MessageType.ResponseQueryOnGuarantees.code)
+      .withHeaders(headers: _*)
 
     val error = BalanceRequestError.badRequestError(
       "Unable to parse required values from IE037 message"
@@ -102,7 +134,7 @@ class BalanceRequestResponseControllerSpec extends AnyFlatSpec with Matchers {
   it should "return 400 when there is an error while validating the message against the XML schema" in {
     val request = FakeRequest()
       .withBody("")
-      .withHeaders(Constants.MessageTypeHeader -> MessageType.ResponseQueryOnGuarantees.code)
+      .withHeaders(headers: _*)
 
     val error = BalanceRequestError.xmlValidationError(
       MessageType.ResponseQueryOnGuarantees,
@@ -138,7 +170,7 @@ class BalanceRequestResponseControllerSpec extends AnyFlatSpec with Matchers {
   it should "return 404 when the balance request to update cannot be found" in {
     val request = FakeRequest()
       .withBody("")
-      .withHeaders(Constants.MessageTypeHeader -> MessageType.ResponseQueryOnGuarantees.code)
+      .withHeaders(headers: _*)
 
     val error = BalanceRequestError.notFoundError(balanceId.messageIdentifier)
 
@@ -156,7 +188,7 @@ class BalanceRequestResponseControllerSpec extends AnyFlatSpec with Matchers {
   it should "return 500 when there is an internal service error" in {
     val request = FakeRequest()
       .withBody("")
-      .withHeaders(Constants.MessageTypeHeader -> MessageType.ResponseQueryOnGuarantees.code)
+      .withHeaders(headers: _*)
 
     val error = BalanceRequestError.internalServiceError()
 
@@ -174,7 +206,7 @@ class BalanceRequestResponseControllerSpec extends AnyFlatSpec with Matchers {
   it should "return 500 when there is some other unexpected error" in {
     val request = FakeRequest()
       .withBody("")
-      .withHeaders(Constants.MessageTypeHeader -> MessageType.ResponseQueryOnGuarantees.code)
+      .withHeaders(headers: _*)
 
     val error = UpstreamServiceError.causedBy(UpstreamErrorResponse("", FORBIDDEN))
 
@@ -192,7 +224,7 @@ class BalanceRequestResponseControllerSpec extends AnyFlatSpec with Matchers {
   it should "return 500 when there is an unhandled exception" in {
     val request = FakeRequest()
       .withBody("")
-      .withHeaders(Constants.MessageTypeHeader -> MessageType.ResponseQueryOnGuarantees.code)
+      .withHeaders(headers: _*)
 
     val result = controller(
       updateBalanceResponse = IO.raiseError(new Exception("Kaboom!!!"))


### PR DESCRIPTION
Adds a metric for measuring the XML recieved on the BalanceRequestResponseController.

Open thoughts:

* For the moment, I have the metrics log to a histogram. I don't know if there is anything that is a better option.
* I get the size of the XML from the content length header. Would we rather get it from the size of the body?
* Key name is not set in stone.

It also looks like `scalafmt` and `scalafix` have altered a couple of other files, mostly imports. I may remove those changes to reduce the diff.