### PR TITLE
Preserve logging MDC information where possible

### DIFF
--- a/app/connectors/CircuitBreakers.scala
+++ b/app/connectors/CircuitBreakers.scala
@@ -21,6 +21,7 @@ import akka.stream.Materializer
 import config.CircuitBreakerConfig
 import logging.Logging
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 trait CircuitBreakers { self: Logging =>
@@ -29,7 +30,7 @@ trait CircuitBreakers { self: Logging =>
 
   private val clazz = getClass.getSimpleName
 
-  lazy val circuitBreaker = new CircuitBreaker(
+  def circuitBreaker(implicit ec: ExecutionContext) = new CircuitBreaker(
     scheduler = materializer.system.scheduler,
     maxFailures = circuitBreakerConfig.maxFailures,
     callTimeout = circuitBreakerConfig.callTimeout,
@@ -37,7 +38,7 @@ trait CircuitBreakers { self: Logging =>
     maxResetTimeout = circuitBreakerConfig.maxResetTimeout,
     exponentialBackoffFactor = circuitBreakerConfig.exponentialBackoffFactor,
     randomFactor = circuitBreakerConfig.randomFactor
-  )(materializer.executionContext)
+  )
     .onOpen(slf4jLogger.error(s"Circuit breaker for ${clazz} opening due to failures"))
     .onHalfOpen(slf4jLogger.warn(s"Circuit breaker for ${clazz} resetting after failures"))
     .onClose {

--- a/app/controllers/ErrorLogging.scala
+++ b/app/controllers/ErrorLogging.scala
@@ -19,9 +19,12 @@ package controllers
 import cats.effect.IO
 import logging.Logging
 import models.errors._
+import uk.gov.hmrc.http.HeaderCarrier
 
 trait ErrorLogging { self: Logging =>
-  def logServiceError[A](action: String, result: Either[BalanceRequestError, A]): IO[Unit] = {
+  def logServiceError[A](action: String, result: Either[BalanceRequestError, A])(implicit
+    hc: HeaderCarrier
+  ): IO[Unit] = {
     result.fold(
       {
         case UpstreamServiceError(_, cause) =>

--- a/app/controllers/testOnly/TestOnlyMongoController.scala
+++ b/app/controllers/testOnly/TestOnlyMongoController.scala
@@ -19,8 +19,11 @@ package controllers.testOnly
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import controllers.actions.IOActions
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import repositories.{BalanceRequestRepository, IOObservables}
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
+import repositories.BalanceRequestRepository
+import repositories.IOObservables
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 

--- a/app/logging/Logging.scala
+++ b/app/logging/Logging.scala
@@ -19,8 +19,11 @@ package logging
 import cats.effect.IO
 import org.slf4j.LoggerFactory
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import uk.gov.hmrc.http.HeaderCarrier
 
 trait Logging {
-  val logger      = Slf4jLogger.getLoggerFromClass[IO](getClass())
-  val slf4jLogger = LoggerFactory.getLogger(getClass())
+  val slf4jLogger         = LoggerFactory.getLogger(getClass())
+  private val basicLogger = Slf4jLogger.getLoggerFromSlf4j[IO](slf4jLogger)
+
+  def logger(implicit hc: HeaderCarrier) = basicLogger.addContext(hc.mdcData)
 }

--- a/app/repositories/BalanceRequestRepository.scala
+++ b/app/repositories/BalanceRequestRepository.scala
@@ -43,6 +43,7 @@ import org.mongodb.scala.model.changestream.FullDocument
 import retry.RetryPolicies
 import retry.syntax.all._
 import runtime.RetryLogging
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.MongoUtils
 import uk.gov.hmrc.mongo.play.json.Codecs
@@ -62,7 +63,7 @@ trait BalanceRequestRepository {
   def insertBalanceRequest(
     balanceRequest: BalanceRequest,
     requestedAt: Instant
-  ): IO[BalanceId]
+  )(implicit hc: HeaderCarrier): IO[BalanceId]
 
   def updateBalanceRequest(
     messageIdentifier: MessageIdentifier,
@@ -130,7 +131,7 @@ class BalanceRequestRepositoryImpl @Inject() (
   def insertBalanceRequest(
     balanceRequest: BalanceRequest,
     requestedAt: Instant
-  ): IO[BalanceId] = {
+  )(implicit hc: HeaderCarrier): IO[BalanceId] = {
     val insertResult = BalanceId.next(clock, random).flatMap { id =>
       val pendingRequest = PendingBalanceRequest(
         balanceId = id,

--- a/app/runtime/IOFutures.scala
+++ b/app/runtime/IOFutures.scala
@@ -17,13 +17,15 @@
 package runtime
 
 import cats.effect.IO
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.logging.Mdc
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 trait IOFutures {
   implicit class IOCompanionFutureOps(io: IO.type) {
-    def runFuture[A](f: ExecutionContext => Future[A]): IO[A] =
-      IO.fromFuture { IO.executionContext.map(f) }
+    def runFuture[A](f: => Future[A])(implicit ec: ExecutionContext, hc: HeaderCarrier): IO[A] =
+      IO.fromFuture { IO(Mdc.withMdc(f, Mdc.mdcData ++ hc.mdcData)) }
   }
 }

--- a/app/services/ErrorTranslationService.scala
+++ b/app/services/ErrorTranslationService.scala
@@ -16,6 +16,7 @@
 
 package services
 
+import com.google.inject.ImplementedBy
 import models.errors.FunctionalError
 import models.errors.XmlError
 import models.values.ErrorPointer
@@ -23,7 +24,6 @@ import models.values.ErrorType
 
 import javax.inject.Inject
 import javax.inject.Singleton
-import com.google.inject.ImplementedBy
 
 @ImplementedBy(classOf[ErrorTranslationServiceImpl])
 trait ErrorTranslationService {

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -51,7 +51,7 @@
 
     <logger name="application" level="DEBUG"/>
 
-    <logger name="connector" level="TRACE">
+    <logger name="connector" level="TRACE" additivity="false">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/it/connectors/EisRouterConnectorSpec.scala
+++ b/it/connectors/EisRouterConnectorSpec.scala
@@ -29,6 +29,7 @@ import play.api.http.HeaderNames
 import play.api.http.MimeTypes
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.RequestId
 import uk.gov.hmrc.http.UpstreamErrorResponse._
 
 import java.time.LocalDateTime
@@ -46,7 +47,10 @@ class EisRouterConnectorSpec
 
   override def portConfigKeys = Seq("microservice.services.eis-router.port")
 
-  implicit val hc = HeaderCarrier(otherHeaders = Seq(Constants.ChannelHeader -> "api"))
+  implicit val hc = HeaderCarrier(
+    requestId = Some(RequestId("6790293d-a688-4d85-9cd4-c8e24e163179")),
+    otherHeaders = Seq(Constants.ChannelHeader -> "api")
+  )
 
   val uuid      = UUID.fromString("22b9899e-24ee-48e6-a189-97d1f45391c4")
   val balanceId = BalanceId(uuid)

--- a/test/controllers/ErrorLoggingSpec.scala
+++ b/test/controllers/ErrorLoggingSpec.scala
@@ -33,6 +33,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.slf4j.LoggerFactory
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
 
 import java.util.UUID
@@ -43,6 +44,8 @@ class ErrorLoggingSpec
   with ScalaCheckPropertyChecks
   with Logging
   with ErrorLogging {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
 
   def withLogAppender[A](test: ListAppender[ILoggingEvent] => A) = {
     val slf4jLogger   = LoggerFactory.getLogger(getClass())

--- a/test/metrics/IOMetricsSpec.scala
+++ b/test/metrics/IOMetricsSpec.scala
@@ -33,10 +33,12 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers
 import play.api.test.Helpers._
 import runtime.IOFutures
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import java.util.concurrent.CancellationException
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -47,25 +49,28 @@ class IOMetricsSpec
   with IdiomaticMockito
   with ArgumentMatchersSugar {
 
+  implicit val ec: ExecutionContext = ExecutionContext.global
+  implicit val hc: HeaderCarrier    = HeaderCarrier()
+
   class IOMetricsConnector(val metrics: Metrics) extends IOFutures with IOMetrics {
     def okHttpCall =
       withMetricsTimerResponse("connector-ok") {
-        IO.runFuture { _ => Future.successful(Right(1)) }
+        IO.runFuture { Future.successful(Right(1)) }
       }
 
     def clientErrorHttpCall =
       withMetricsTimerResponse("connector-client-error") {
-        IO.runFuture { _ => Future.successful(Left(UpstreamErrorResponse("Arghhh!!!", 400))) }
+        IO.runFuture { Future.successful(Left(UpstreamErrorResponse("Arghhh!!!", 400))) }
       }
 
     def serverErrorHttpCall =
       withMetricsTimerResponse("connector-server-error") {
-        IO.runFuture { _ => Future.successful(Left(UpstreamErrorResponse("Kaboom!!!", 502))) }
+        IO.runFuture { Future.successful(Left(UpstreamErrorResponse("Kaboom!!!", 502))) }
       }
 
     def unhandledExceptionHttpCall =
       withMetricsTimerResponse("connector-unhandled-exception") {
-        IO.runFuture { _ => Future.failed(new RuntimeException) }
+        IO.runFuture { Future.failed(new RuntimeException) }
       }
 
     def cancelledHttpCall =

--- a/test/models/formats/AuditEventFormatsSpec.scala
+++ b/test/models/formats/AuditEventFormatsSpec.scala
@@ -21,6 +21,7 @@ import models.audit.ErrorResponseEvent
 import models.audit.InvalidResponseEvent
 import models.audit.RequestEvent
 import models.audit.RequestNotFoundEvent
+import models.audit.ResponseEvent
 import models.audit.SuccessResponseEvent
 import models.request.AuthenticatedRequest
 import models.request.BalanceRequest
@@ -36,7 +37,6 @@ import play.api.libs.json._
 import play.api.test.FakeRequest
 
 import java.util.UUID
-import models.audit.ResponseEvent
 
 class AuditEventFormatsSpec extends AnyFlatSpec with Matchers {
   val uuid      = UUID.fromString("22b9899e-24ee-48e6-a189-97d1f45391c4")

--- a/test/repositories/BalanceRequestRepositorySpec.scala
+++ b/test/repositories/BalanceRequestRepositorySpec.scala
@@ -33,6 +33,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Configuration
 import play.api.test.DefaultAwaitTimeout
 import play.api.test.FutureAwaits
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -53,7 +54,9 @@ class BalanceRequestRepositorySpec
   with DefaultAwaitTimeout
   with DefaultPlayMongoRepositorySupport[PendingBalanceRequest] {
 
-  implicit val ec    = ExecutionContext.global
+  implicit val ec: ExecutionContext = ExecutionContext.global
+  implicit val hc: HeaderCarrier    = HeaderCarrier()
+
   override val clock = Clock.tickSeconds(ZoneOffset.UTC)
   val random         = new SecureRandom
 

--- a/test/repositories/FakeBalanceRequestRepository.scala
+++ b/test/repositories/FakeBalanceRequestRepository.scala
@@ -26,6 +26,7 @@ import models.request.BalanceRequest
 import models.values.BalanceId
 import models.values.MessageIdentifier
 import org.mongodb.scala.bson.collection.immutable.Document
+import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.Instant
 
@@ -42,7 +43,7 @@ case class FakeBalanceRequestRepository(
   override def insertBalanceRequest(
     balanceRequest: BalanceRequest,
     requestedAt: Instant
-  ): IO[BalanceId] =
+  )(implicit hc: HeaderCarrier): IO[BalanceId] =
     insertBalanceRequestResponse
 
   override def updateBalanceRequest(

--- a/test/runtime/IOFuturesSpec.scala
+++ b/test/runtime/IOFuturesSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.test.DefaultAwaitTimeout
 import play.api.test.FutureAwaits
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -36,11 +37,12 @@ class IOFuturesSpec
   with IOFutures {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
+  implicit val hc: HeaderCarrier    = HeaderCarrier()
 
   "IO.runFuture" should "run successful Futures to identical result" in forAll {
     (fn: (String => Int), str: String) =>
       val viaIO =
-        IO.runFuture { implicit ec => Future(str)(ec).map(fn)(ec) }.unsafeToFuture()
+        IO.runFuture { Future(str)(ec).map(fn)(ec) }.unsafeToFuture()
 
       val viaFuture =
         Future(str).map(fn)
@@ -57,7 +59,7 @@ class IOFuturesSpec
     val exc = new RuntimeException
 
     val viaIO =
-      IO.runFuture { _ => Future(num).map[Int](_ => throw exc) }.unsafeToFuture()
+      IO.runFuture { Future(num).map[Int](_ => throw exc) }.unsafeToFuture()
 
     val viaFuture =
       Future(num).map[Int](_ => throw exc)


### PR DESCRIPTION
HMRC's integration with Kibana makes use of a JSON logging encoder which encodes the SLF4J MDC into the log event in order to record request tracing information like the request and session ID. 

This doesn't work very well in multithreaded scenarios because the MDC is thread-local data and frameworks like akka and cats-effect shift work between threads pretty frequently, meaning that MDC data intermittently goes missing for certain log statements depending upon how work is allocated to the underlying worker threads (see e.g. https://github.com/playframework/playframework/issues/7458).

We can fix this in `log4cats` logging calls by using the structured logging API that it offers to add the request information to the base context for the logger, which fixes the problem in our own code, but this still presents difficulties when we hand off to other libraries like internal HMRC ones and the Akka circuit breaker. The best we can do there is to add the MDC info we're interested in before handing off to the library call.