### PR TITLE
Revert "Revert "Add owner principal EORI to the request XML""

### DIFF
--- a/app/services/XmlFormattingService.scala
+++ b/app/services/XmlFormattingService.scala
@@ -71,6 +71,9 @@ class XmlFormattingServiceImpl @Inject() () extends XmlFormattingService {
         <GUAQUE>
           <QueIdeQUE1>2</QueIdeQUE1>
         </GUAQUE>
+        <TRAPRIOTG>
+          <TINOTG59>{request.taxIdentifier.value}</TINOTG59>
+        </TRAPRIOTG>
         <ACCDOC728>
           <AccCodCOD729>{request.accessCode.value}</AccCodCOD729>
         </ACCDOC728>

--- a/test/models/values/UniqueReferenceSpec.scala
+++ b/test/models/values/UniqueReferenceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/services/BalanceRequestServiceSpec.scala
+++ b/test/services/BalanceRequestServiceSpec.scala
@@ -177,8 +177,8 @@ class BalanceRequestServiceSpec extends AsyncFlatSpec with Matchers {
         <MesRecMES6>NTA.GB</MesRecMES6>
         <DatOfPreMES9>ABC12345</DatOfPreMES9>
         <TimOfPreMES10>1504</TimOfPreMES10>
-        <IntConRefMES11>deadbeefcafeba</IntConRefMES11>
-        <MesIdeMES19>deadbeefcafeba</MesIdeMES19>
+        <IntConRefMES11>jh8v8a7z7hzmq3</IntConRefMES11>
+        <MesIdeMES19>jh8v8a7z7hzmq3</MesIdeMES19>
         <MesTypMES20>GB034A</MesTypMES20>
         <TRAPRIRC1>
           <TINRC159>GB12345678900</TINRC159>
@@ -188,6 +188,9 @@ class BalanceRequestServiceSpec extends AsyncFlatSpec with Matchers {
           <GUAQUE>
             <QueIdeQUE1>2</QueIdeQUE1>
           </GUAQUE>
+          <TRAPRIOTG>
+            <TINOTG59>GB12345678900</TINOTG59>
+          </TRAPRIOTG>
           <ACCDOC728>
             <AccCodCOD729>ABC1</AccCodCOD729>
           </ACCDOC728>

--- a/test/services/XmlFormattingServiceSpec.scala
+++ b/test/services/XmlFormattingServiceSpec.scala
@@ -61,6 +61,9 @@ class XmlFormattingServiceSpec extends AnyFlatSpec with Matchers with Streamline
           <GUAQUE>
             <QueIdeQUE1>2</QueIdeQUE1>
           </GUAQUE>
+          <TRAPRIOTG>
+            <TINOTG59>GB12345678900</TINOTG59>
+          </TRAPRIOTG>
           <ACCDOC728>
             <AccCodCOD729>1234</AccCodCOD729>
           </ACCDOC728>

--- a/test/services/XmlParsingServiceSpec.scala
+++ b/test/services/XmlParsingServiceSpec.scala
@@ -44,8 +44,8 @@ class XmlParsingServiceSpec extends AnyFlatSpec with Matchers with EitherValues 
       <MesRecMES6>MDTP-GUA-22b9899e24ee48e6a18997d1</MesRecMES6>
       <DatOfPreMES9>20210806</DatOfPreMES9>
       <TimOfPreMES10>1505</TimOfPreMES10>
-      <IntConRefMES11>60b420bb3851d9</IntConRefMES11>
-      <MesIdeMES19>60b420bb3851d9</MesIdeMES19>
+      <IntConRefMES11>jh8v8a7z7hzmq3</IntConRefMES11>
+      <MesIdeMES19>jh8v8a7z7hzmq3</MesIdeMES19>
       <MesTypMES20>GB037A</MesTypMES20>
       <TRAPRIRC1>
         <TINRC159>GB12345678900</TINRC159>
@@ -78,8 +78,8 @@ class XmlParsingServiceSpec extends AnyFlatSpec with Matchers with EitherValues 
       <MesRecMES6>MDTP-GUA-22b9899e24ee48e6a18997d1</MesRecMES6>
       <DatOfPreMES9>20210806</DatOfPreMES9>
       <TimOfPreMES10>1505</TimOfPreMES10>
-      <IntConRefMES11>60b420bb3851d9</IntConRefMES11>
-      <MesIdeMES19>60b420bb3851d9</MesIdeMES19>
+      <IntConRefMES11>jh8v8a7z7hzmq3</IntConRefMES11>
+      <MesIdeMES19>jh8v8a7z7hzmq3</MesIdeMES19>
       <MesTypMES20>GB037A</MesTypMES20>
       <TRAPRIRC1>
         <TINRC159>GB12345678900</TINRC159>
@@ -111,8 +111,8 @@ class XmlParsingServiceSpec extends AnyFlatSpec with Matchers with EitherValues 
       <MesRecMES6>MDTP-GUA-22b9899e24ee48e6a18997d1</MesRecMES6>
       <DatOfPreMES9>20210907</DatOfPreMES9>
       <TimOfPreMES10>1553</TimOfPreMES10>
-      <IntConRefMES11>60b420bb3851d9</IntConRefMES11>
-      <MesIdeMES19>60b420bb3851d9</MesIdeMES19>
+      <IntConRefMES11>jh8v8a7z7hzmq3</IntConRefMES11>
+      <MesIdeMES19>jh8v8a7z7hzmq3</MesIdeMES19>
       <MesTypMES20>GB906A</MesTypMES20>
       <OriMesIdeMES22>MDTP-GUA-00000000000000000000001-01</OriMesIdeMES22>
       <FUNERRER1>
@@ -130,8 +130,8 @@ class XmlParsingServiceSpec extends AnyFlatSpec with Matchers with EitherValues 
       <MesRecMES6>MDTP-GUA-22b9899e24ee48e6a18997d1</MesRecMES6>
       <DatOfPreMES9>20210907</DatOfPreMES9>
       <TimOfPreMES10>1553</TimOfPreMES10>
-      <IntConRefMES11>60b420bb3851d9</IntConRefMES11>
-      <MesIdeMES19>60b420bb3851d9</MesIdeMES19>
+      <IntConRefMES11>jh8v8a7z7hzmq3</IntConRefMES11>
+      <MesIdeMES19>jh8v8a7z7hzmq3</MesIdeMES19>
       <MesTypMES20>GB906A</MesTypMES20>
       <OriMesIdeMES22>MDTP-GUA-00000000000000000000001-01</OriMesIdeMES22>
       <FUNERRER1>
@@ -148,8 +148,8 @@ class XmlParsingServiceSpec extends AnyFlatSpec with Matchers with EitherValues 
       <MesRecMES6>MDTP-GUA-22b9899e24ee48e6a18997d1</MesRecMES6>
       <DatOfPreMES9>20210907</DatOfPreMES9>
       <TimOfPreMES10>1553</TimOfPreMES10>
-      <IntConRefMES11>60b420bb3851d9</IntConRefMES11>
-      <MesIdeMES19>60b420bb3851d9</MesIdeMES19>
+      <IntConRefMES11>jh8v8a7z7hzmq3</IntConRefMES11>
+      <MesIdeMES19>jh8v8a7z7hzmq3</MesIdeMES19>
       <MesTypMES20>GB917A</MesTypMES20>
       <HEAHEA>
         <OriMesIdeMES22>MDTP-GUA-00000000000000000000001-01</OriMesIdeMES22>
@@ -168,8 +168,8 @@ class XmlParsingServiceSpec extends AnyFlatSpec with Matchers with EitherValues 
       <MesRecMES6>MDTP-GUA-22b9899e24ee48e6a18997d1</MesRecMES6>
       <DatOfPreMES9>20210907</DatOfPreMES9>
       <TimOfPreMES10>1553</TimOfPreMES10>
-      <IntConRefMES11>60b420bb3851d9</IntConRefMES11>
-      <MesIdeMES19>60b420bb3851d9</MesIdeMES19>
+      <IntConRefMES11>jh8v8a7z7hzmq3</IntConRefMES11>
+      <MesIdeMES19>jh8v8a7z7hzmq3</MesIdeMES19>
       <MesTypMES20>GB917A</MesTypMES20>
       <HEAHEA>
         <OriMesIdeMES22>MDTP-GUA-00000000000000000000001-01</OriMesIdeMES22>

--- a/test/services/XmlValidationServiceSpec.scala
+++ b/test/services/XmlValidationServiceSpec.scala
@@ -56,6 +56,9 @@ class XmlValidationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
         <GUAQUE>
           <QueIdeQUE1>2</QueIdeQUE1>
         </GUAQUE>
+        <TRAPRIOTG>
+          <TINOTG59>GB12345678900</TINOTG59>
+        </TRAPRIOTG>
         <ACCDOC728>
           <AccCodCOD729>ABC1</AccCodCOD729>
         </ACCDOC728>
@@ -116,6 +119,9 @@ class XmlValidationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
         <GUAQUE>
           <QueIdeQUE1>2</QueIdeQUE1>
         </GUAQUE>
+        <TRAPRIOTG>
+          <TINOTG59>GB12345678900</TINOTG59>
+        </TRAPRIOTG>
         <ACCDOC728>
           <AccCodCOD729>ABC1</AccCodCOD729>
         </ACCDOC728>
@@ -142,6 +148,9 @@ class XmlValidationServiceSpec extends AnyFlatSpec with Matchers with EitherValu
         <GUAQUE>
           <QueIdeQUE1>2</QueIdeQUE1>
         </GUAQUE>
+        <TRAPRIOTG>
+          <TINOTG59>GB12345678900</TINOTG59>
+        </TRAPRIOTG>
         <ACCDOC728>
           <AccCodCOD729>ABC1</AccCodCOD729>
         </ACCDOC728>


### PR DESCRIPTION
Reverts hmrc/transit-movements-guarantee-balance#31

Spoke to Scott about this a bit more and convinced myself that this was correct after all - the user supplies the taxIdentifier value, so as long as they know the principal EORI for the guarantee, it should be correct to copy it both into the requester field and the guarantee principal owner field.